### PR TITLE
Fix save handler for Haskell files

### DIFF
--- a/packs/stable/lang-pack/config/haskell-conf.el
+++ b/packs/stable/lang-pack/config/haskell-conf.el
@@ -2,6 +2,7 @@
 (require 'haskell-font-lock)
 (require 'haskell-simple-indent)
 (require 'haskell-mode)
+(require 'haskell)
 
 
 (add-to-list 'auto-mode-alist        '("\\.\\(?:[gh]s\\|hi\\)\\'" . haskell-mode))


### PR DESCRIPTION
When try to save buffer to a file the following error occurs:

run-hooks: Symbol's function definition is void: haskell-mode-after-save-handler
